### PR TITLE
feat: Plan 엔터티 description 필드를 nullable로 변경

### DIFF
--- a/src/main/java/com/world/planner/plan/domain/Plan.java
+++ b/src/main/java/com/world/planner/plan/domain/Plan.java
@@ -26,7 +26,7 @@ public class Plan extends BaseEntity {
   @Column(nullable = false, length = 100)
   private String title;
 
-  @Column(nullable = false, length = 500)
+  @Column(length = 500)
   private String description;
 
   @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})

--- a/src/main/java/com/world/planner/plan/presentation/dto/request/CreatePlanRequest.java
+++ b/src/main/java/com/world/planner/plan/presentation/dto/request/CreatePlanRequest.java
@@ -13,7 +13,6 @@ public class CreatePlanRequest {
   @Schema(description = "Plan 제목", example = "Weekly Meeting")
   private String title;
 
-  @NotBlank(message = "Plan 설명은 반드시 입력해야 합니다.")
   @Schema(description = "Plan 설명", example = "Discussion about project updates")
   private String description;
 

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS recurrence_rule (
 CREATE TABLE IF NOT EXISTS plans (
   id UUID PRIMARY KEY,
   title VARCHAR(100) NOT NULL,
-  description VARCHAR(500) NOT NULL,
+  description VARCHAR(500) NULL,
   start_date DATE NULL,
   end_date DATE NULL,
   recurrence_rule_id UUID,


### PR DESCRIPTION
Plan 엔터티의 `description` 필드를 nullable로 변경하는 작업을 진행했습니다. 아래는 주요 변경사항입니다:
**주요 변경사항**
1. **Plan 엔터티 필드 수정**
    - `description` 필드에 nullable 속성 추가:
`@Column(nullable = false)` → `@Column(nullable = true)`.
    - 이로 인해 데이터베이스에서 description 값의 null 허용 가능.

2. **데이터베이스 스키마 변경**
    - `ALTER TABLE plans ALTER COLUMN description DROP NOT NULL` 명령을 통해 NOT NULL 제약 조건 제거.

3. **DTO 수정**
    - `@NotNull` 등의 유효성 검증 제거로 null 값 허용.

4. **Plan 생성 및 수정 로직 변경**
    - `Plan.create` 및 `updateDetails` 메서드를 수정하여 `description` 필드에 null 허용.
