### PR TITLE
feat: 카카오 OAuth 로그인 및 인증 기능 구현

### DIFF
--- a/src/main/java/com/world/planner/auth/application/KakaoAuthService.java
+++ b/src/main/java/com/world/planner/auth/application/KakaoAuthService.java
@@ -1,0 +1,22 @@
+package com.world.planner.auth.application;
+
+import com.world.planner.auth.domain.KakaoUser;
+import com.world.planner.auth.infrastructure.KakaoApiClient;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoAuthService {
+
+  private final KakaoApiClient kakaoApiClient;
+
+  public KakaoUser authenticateKakaoUser(String code) {
+    // Access Token 발급
+    String accessToken = kakaoApiClient.getAccessToken(code);
+
+    // 사용자 정보 가져오기
+    return kakaoApiClient.getUserInfo(accessToken);
+  }
+}

--- a/src/main/java/com/world/planner/auth/domain/KakaoUser.java
+++ b/src/main/java/com/world/planner/auth/domain/KakaoUser.java
@@ -1,0 +1,28 @@
+package com.world.planner.auth.domain;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class KakaoUser {
+
+  private final Long id;
+  private final String nickname;
+  private final String email;
+
+  private KakaoUser(Long id, String nickname, String email) {
+    this.id = id;
+    this.nickname = nickname;
+    this.email = email;
+  }
+
+  public static KakaoUser create(Long id, String nickname, String email) {
+    return new KakaoUser(id, nickname, email);
+  }
+
+  // 도메인 로직 추가 가능
+  public boolean isValid() {
+    return id != null && nickname != null && !nickname.isEmpty();
+  }
+}

--- a/src/main/java/com/world/planner/auth/infrastructure/KakaoApiClient.java
+++ b/src/main/java/com/world/planner/auth/infrastructure/KakaoApiClient.java
@@ -1,0 +1,125 @@
+package com.world.planner.auth.infrastructure;
+
+import com.world.planner.auth.domain.KakaoUser;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+@Slf4j
+public class KakaoApiClient {
+
+  private static final RestTemplate REST_TEMPLATE = new RestTemplate();
+  private static final String TOKEN_REQUEST_URL = "https://kauth.kakao.com/oauth/token";
+  private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+  @Value("${kakao.auth.client-id}")
+  private String clientId;
+
+  @Value("${kakao.auth.redirect-uri}")
+  private String redirectUri;
+
+  public String getAccessToken(String code) {
+    // Access Token 요청을 위한 HTTP Header와 Body 구성
+    HttpHeaders headers = createHeaders(MediaType.APPLICATION_FORM_URLENCODED, null);
+    MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+    body.add("grant_type", "authorization_code");
+    body.add("client_id", clientId);
+    body.add("redirect_uri", redirectUri);
+    body.add("code", code);
+
+    // 액세스 토큰 요청
+    return executePostRequest(TOKEN_REQUEST_URL, new HttpEntity<>(body, headers), Map.class)
+        .map(responseBody -> (String) responseBody.get("access_token"))
+        .orElseThrow(() -> new IllegalStateException("Failed to retrieve access token: No access token in response."));
+  }
+
+  public KakaoUser getUserInfo(String accessToken) {
+    // 사용자 정보 요청을 위한 HTTP Header만 구성
+    HttpHeaders headers = createHeaders(null, accessToken);
+    HttpEntity<?> request = new HttpEntity<>(headers);
+
+    // 사용자 정보 요청 및 유저 생성
+    return executeGetRequest(USER_INFO_URL, request, Map.class)
+        .map(this::mapToKakaoUser)
+        .orElseThrow(() -> new IllegalStateException("Failed to retrieve user info: Response was invalid."));
+  }
+
+  private HttpHeaders createHeaders(MediaType contentType, String accessToken) {
+    HttpHeaders headers = new HttpHeaders();
+    if (contentType != null) {
+      headers.setContentType(contentType);
+    }
+    if (accessToken != null) {
+      headers.set("Authorization", "Bearer " + accessToken);
+    }
+    return headers;
+  }
+
+  private KakaoUser mapToKakaoUser(Map<String, Object> userInfo) {
+    // 사용자 정보가 없거나 ID가 없으면 예외 처리
+    if (userInfo == null || !userInfo.containsKey("id")) {
+      log.error("Failed to parse user info: {}", userInfo);
+      throw new IllegalStateException("Failed to retrieve valid user info.");
+    }
+
+    // 이메일 처리
+    Map<String, String> kakaoAccount = (Map<String, String>) userInfo.get("kakao_account");
+    String email = kakaoAccount != null ? kakaoAccount.get("email") : null;
+
+    // 닉네임 처리
+    Map<String, Object> properties = (Map<String, Object>) userInfo.get("properties");
+    String nickname = properties != null ? (String) properties.getOrDefault("nickname", "Unknown") : "Unknown";
+
+    return KakaoUser.create(
+        (Long) userInfo.get("id"),
+        nickname,
+        email
+    );
+  }
+
+  private <T> Optional<T> executePostRequest(String url, HttpEntity<?> request, Class<T> responseType) {
+    try {
+      ResponseEntity<T> response = REST_TEMPLATE.exchange(url, HttpMethod.POST, request, responseType);
+      return Optional.ofNullable(response.getBody());
+    } catch (HttpClientErrorException e) {
+      handleHttpClientError(url, e);
+      return Optional.empty();
+    } catch (Exception e) {
+      handleUnexpectedError(url, e);
+      return Optional.empty();
+    }
+  }
+
+  private <T> Optional<T> executeGetRequest(String url, HttpEntity<?> request, Class<T> responseType) {
+    try {
+      ResponseEntity<T> response = REST_TEMPLATE.exchange(url, HttpMethod.GET, request, responseType);
+      return Optional.ofNullable(response.getBody());
+    } catch (HttpClientErrorException e) {
+      handleHttpClientError(url, e);
+      return Optional.empty();
+    } catch (Exception e) {
+      handleUnexpectedError(url, e);
+      return Optional.empty();
+    }
+  }
+
+  private void handleHttpClientError(String url, HttpClientErrorException e) {
+    log.error("HTTP Client Error during request to {}: Status Code = {}, Response Body = {}",
+        url, e.getStatusCode(), e.getResponseBodyAsString(), e);
+    throw new IllegalStateException("HTTP request failed: " + e.getMessage(), e);
+  }
+
+  private void handleUnexpectedError(String url, Exception e) {
+    log.error("Unexpected error during request to {}", url, e);
+    throw new IllegalStateException("Unexpected error during HTTP request.", e);
+  }
+}

--- a/src/main/java/com/world/planner/auth/presentation/KakaoAuthRestController.java
+++ b/src/main/java/com/world/planner/auth/presentation/KakaoAuthRestController.java
@@ -1,0 +1,41 @@
+package com.world.planner.auth.presentation;
+
+import com.world.planner.auth.application.KakaoAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Kakao Authentication", description = "카카오 로그인 및 사용자 인증 API")
+@RestController
+@RequestMapping("/auth/kakao")
+@RequiredArgsConstructor
+public class KakaoAuthRestController {
+
+  private final KakaoAuthService kakaoAuthService;
+
+  @Operation(
+      summary = "카카오 로그인 콜백 처리",
+      description = "카카오 OAuth 인증 과정에서 발급된 인가 코드를 사용하여 사용자 인증을 처리합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "카카오 사용자 인증 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (예: 인가 코드 누락)"),
+      @ApiResponse(responseCode = "500", description = "서버 오류")
+  })
+  @GetMapping("/callback")
+  public ResponseEntity<?> kakaoCallback(
+      @Parameter(description = "카카오 OAuth 인증을 통해 발급된 인가 코드", required = true)
+      @RequestParam("code") String code
+  ) {
+    // TODO JWT 기능 추가
+    return ResponseEntity.ok(kakaoAuthService.authenticateKakaoUser(code));
+  }
+}

--- a/src/main/java/com/world/planner/global/config/WebConfig.java
+++ b/src/main/java/com/world/planner/global/config/WebConfig.java
@@ -23,8 +23,10 @@ public class WebConfig implements WebMvcConfigurer {
       throw new IllegalStateException("CORS allowedOrigins 설정이 누락되었습니다.");
     }
     registry.addMapping("/**")
+        .allowedOrigins("http://localhost:3000")
         .allowedOrigins(allowedOrigins.toArray(new String[0])) // 프로파일에 따라 Origin이 동적으로 설정됨
         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-        .allowedHeaders("*");
+        .allowedHeaders("*")
+        .allowCredentials(true);
   }
 }

--- a/src/main/java/com/world/planner/global/security/SecurityConfig.java
+++ b/src/main/java/com/world/planner/global/security/SecurityConfig.java
@@ -6,6 +6,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class SecurityConfig {
@@ -14,11 +16,29 @@ public class SecurityConfig {
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http.authorizeHttpRequests(auth -> auth
             .requestMatchers("/h2-console/**").permitAll() // H2 Console 요청 허용
-            .anyRequest().permitAll()
+            .requestMatchers("/auth/kakao/callback").permitAll() // 해당 엔드포인트 허용
+            .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs.yaml").permitAll() // Swagger 관련 경로 허용
+            .requestMatchers("/api/members/social-login").permitAll()
+            .anyRequest().authenticated() // 다른 요청은 인증 필요
         )
         .csrf(AbstractHttpConfigurer::disable) // CSRF 비활성화
+        .cors(cors -> {}) // CORS 설정 활성화
         .headers(headers -> headers.frameOptions(FrameOptionsConfig::disable)); // IFrame 방어 비활성화
 
     return http.build();
+  }
+
+  // CORS 설정 추가
+  @Bean
+  public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // 모든 엔드포인트에 대해
+            .allowedOrigins("http://localhost:3000") // 프론트엔드 React 서버 도메인
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 허용할 HTTP 메서드
+            .allowCredentials(true); // 쿠키 및 인증정보 허용
+      }
+    };
   }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,3 +19,14 @@ spring:
 cors:
   allowed-origins:
     - https://dev.treat-well-planner.com
+
+logging:
+  level:
+    org:
+      springdoc: DEBUG
+      springframework:
+        security: DEBUG
+
+kakao:
+  auth:
+    redirect-uri: https://dev.treat-well-planner.com/auth/kakao/callback

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,7 +12,10 @@ spring:
 
 logging:
   level:
-    org.springdoc: DEBUG
+    org:
+      springdoc: DEBUG
+      springframework:
+        security: DEBUG
 #    name: treat_well_planner
 #    url: jdbc:h2:mem:treat_well_planner;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 #    username: sa
@@ -41,3 +44,9 @@ cors:
   allowed-origins:
     - http://localhost:8080
     - http://127.0.0.1:8080
+    - http://localhost:3000
+    - http://127.0.0.1:3000
+
+kakao:
+  auth:
+    redirect-uri: http://localhost:8080/auth/kakao/callback

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,3 +20,7 @@ spring:
 cors:
   allowed-origins:
     - https://treat-well-planner.com
+
+kakao:
+  auth:
+    redirect-uri: https://treat-well-planner.com/auth/kakao/callback

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,4 +32,14 @@ server:
       enabled: true
       force: true
 jwt:
-  secret-key: WjdX/OI18DWmUGOl+U+FmRnYsc/bdFCrlwbQLpvPesnS6VLN2oU3Ps3xTDkcb8JriAP8UmlA5+Mla5YWARg8Sg==
+  secret-key: ENC(LpJ6Iz8zEA3gKFCyZocT6cPn8+GJFxdEDrfjeW6wtOyGkKs9UrGdduF2kxlxNB/a6fmVNxO7BfQ=)
+
+kakao:
+  auth:
+    client-id: ENC(1s4fH/o9b/BmmBJ0T4CQKEGGCBthHJK+iqin7OQuce7+gkArhFtRiIeM/hs6yy/cy/tu/xVFcUk=)
+    redirect-uri: http://localhost:8080/auth/kakao/callback
+
+jasypt:
+  encryptor:
+    iv-generator-classname: org.jasypt.iv.NoIvGenerator
+    algorithm: PBEWithMD5AndDES


### PR DESCRIPTION
### 📝 요약
카카오 OAuth 로그인 및 인증 기능을 구현한 Pull Request입니다.

### 🔧 변경 사항
1. **KakaoApiClient**
   - 카카오 API를 활용한 OAuth 토큰 요청 및 사용자 정보 조회 처리.
2. **KakaoUser 도메인**
   - 카카오에서 반환된 사용자 기본 정보를 담는 도메인 생성.
3. **KakaoAuthService**
   - 인증 흐름 관리 (토큰 처리, 사용자 검증 등).
4. **KakaoAuthRestController**
   - 카카오 콜백 URL을 처리하고 로그인 과정을 실행하는 컨트롤러 추가.
5. **CORS 설정**
   - React 프론트엔드(`http://localhost:3000`)의 요청을 허용하도록 CORS 설정 추가.
6. **오류 처리**
   - API 호출 중 발생 가능한 오류 대응 및 방어 코드 작성.

### 🚀 목적
카카오 OAuth를 사용하는 소셜 로그인을 구현하여 인증 과정을 간소화하고 플랫폼의 로그인 기능을 향상합니다.

### ✅ 체크리스트
- [x] 카카오 OAuth 관련 인프라 구성.
- [x] 사용자 도메인 모델(KakaoUser) 추가.
- [x] 방어적 코딩 및 예외 처리 반영.
- [x] 프론트엔드와 통신을 위한 CORS 설정 추가.

### 🛠️ 관련 링크
- **카카오 API 문서**: [카카오 OAuth 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api)

### ⚠️ 참고사항
- 환경 변수(`kakao.auth.client-id`, `kakao.auth.redirect-uri`)를 Dev 환경에서 올바르게 설정한 후 테스트하세요.
- 프로덕션 환경에서는 CORS 설정을 보안 정책에 맞게 변경해야 합니다.